### PR TITLE
app.musemuse.cn and share.musemuse.cn

### DIFF
--- a/TikTok/tiktokblocklist.txt
+++ b/TikTok/tiktokblocklist.txt
@@ -27,6 +27,8 @@
 0.0.0.0 sgali3.l.byteoversea.net
 0.0.0.0 tiktokcdn-com.akamaized.net
 0.0.0.0 ibytedtos.com
+0.0.0.0 app.musemuse.cn
+0.0.0.0 share.musemuse.cn
 
 # ===============================================================
 


### PR DESCRIPTION
I noticed app.musemuse.cn and share.musemuse.cn in my dns log.

I could not find much about them but based on this site https://redskyalliance.org/xindustry/misty-hong-v-tiktok-claimed-details-of-how-tikkok-illegally-colle its a tiktok domain.