### PR TITLE
Removed star.c10r.facebook.com

### DIFF
--- a/MobileAppAds/appadsblocklist.txt
+++ b/MobileAppAds/appadsblocklist.txt
@@ -618,7 +618,6 @@ spaceshooter.rocketstudio.com.vn
 sponsorpay.com
 ssl.google-analytics.com
 st.bebi.com
-star.c10r.facebook.com
 startapp.com
 startappexchange.com
 startappservice.com


### PR DESCRIPTION
- Removed star.c10r.facebook.com to fix issues related to facebook taking long to load, watch/video section not loading.